### PR TITLE
Fixed one forgotten variable rename update

### DIFF
--- a/lib/AccessToken.js
+++ b/lib/AccessToken.js
@@ -41,7 +41,7 @@ AccessToken.verify = function (token, options, callback) {
     random: function (done) {
       if (token.indexOf('.') === -1) {
         request
-          .post(options.iss + '/token/verify')
+          .post(options.issuer + '/token/verify')
           .set('Authorization', 'Bearer ' + options.jwt)
           .set('Content-Type',  'application/json')
           .send({ access_token: token })


### PR DESCRIPTION
The `options` object on AccessToken.verify was modified in 6baf47c764f to expect an attribute of `issuer` instead of `iss`. This causes an error becuase the DNS library is not able to resolve a host of 'undefined'.

Updates were made on line 74 (related to line 80) in that commit, but the call in the `random` function was forgotten.

This fixes that.
