### PR TITLE
Use correct property on Error object

### DIFF
--- a/errors/UnauthorizedError.js
+++ b/errors/UnauthorizedError.js
@@ -12,7 +12,7 @@ var util = require('util');
 function UnauthorizedError(options, status) {
   this.name              = 'UnauthorizedError';
   this.error             = options.error;
-  this.error_description = options.error_description;
+  this.message           = options.error_description;
   //this.realm             = options.realm;
   //this.scope             = options.scope;
   this.statusCode        = options.statusCode || 401;


### PR DESCRIPTION
The `Error` object has a standard `message` property which `CallbackError` correctly uses, and which `UnauthorizedError` should use.