### PR TITLE
Access token argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,17 +348,22 @@ AnvilConnect.prototype.token = token
  * User Info
  */
 
-function userInfo () {
+function userInfo (options) {
+  options = options || {}
+
   var uri = this.configuration.userinfo_endpoint
-  var token = this.tokens.access_token
   var self = this
 
   return new Promise(function (resolve, reject) {
+    if (!options.token) {
+      return reject(new Error('Missing access token'))
+    }
+
     request({
       url: uri,
       method: 'GET',
       headers: {
-        'Authorization': 'Bearer ' + token
+        'Authorization': 'Bearer ' + options.token
       },
       json: true,
       agentOptions: self.agentOptions

--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@ var async = require('async')
 var request = require('request-promise')
 var clients = require('./rest/clients')
 var roles = require('./rest/roles')
+var roleScopes = require('./rest/roleScopes')
 var scopes = require('./rest/scopes')
 var users = require('./rest/users')
+var userRoles = require('./rest/userRoles')
 var IDToken = require('./lib/IDToken')
 var AccessToken = require('./lib/AccessToken')
 var UnauthorizedError = require('./errors/UnauthorizedError')
@@ -41,7 +43,12 @@ function AnvilConnect (options) {
     get: roles.get.bind(this),
     create: roles.create.bind(this),
     update: roles.update.bind(this),
-    delete: roles.delete.bind(this)
+    delete: roles.delete.bind(this),
+    scopes: {
+      list: roleScopes.listScopes.bind(this),
+      add: roleScopes.addScope.bind(this),
+      delete: roleScopes.deleteScope.bind(this)
+    }
   }
 
   this.scopes = {
@@ -57,7 +64,12 @@ function AnvilConnect (options) {
     get: users.get.bind(this),
     create: users.create.bind(this),
     update: users.update.bind(this),
-    delete: users.delete.bind(this)
+    delete: users.delete.bind(this),
+    roles: {
+      list: userRoles.listRoles.bind(this),
+      add: userRoles.addRole.bind(this),
+      delete: userRoles.deleteRole.bind(this)
+    }
   }
 
   // add scope to defaults

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,47 @@
+/**
+ * Module dependencies
+ */
+
+var request = require('request-promise')
+
+/**
+ * Protected API Request
+ */
+
+function protectedAPIRequest (options) {
+  var self = this
+
+  return new Promise(function (resolve, reject) {
+    options = options || {}
+
+    // validate the options
+    if (!options.url) { return reject(new Error('Missing request url')) }
+    if (!options.token) { return reject(new Error('Missing access token')) }
+
+    // initialize default values
+    if (!options.url.match(/^http/)) {
+      options.url = self.configuration.issuer + options.url
+    }
+
+    options.method = options.method || 'GET'
+    options.headers = options.headers || {}
+    options.headers['Authorization'] = 'Bearer ' + options.token
+    options.json = options.json || true
+    options.agentOptions = self.agentOptions
+
+    // make the request
+    request(options)
+    .then(function (data) {
+      resolve(data)
+    })
+    .catch(function (err) {
+      reject(err)
+    })
+  })
+}
+
+/**
+ * Export
+ */
+
+module.exports = protectedAPIRequest

--- a/rest/clients.js
+++ b/rest/clients.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Clients
  */
 
 function listClients (options) {
-  var uri = this.configuration.issuer + '/v1/clients'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/clients'
+  return request.bind(this)(options)
 }
 
 exports.list = listClients
@@ -39,27 +21,9 @@ exports.list = listClients
  */
 
 function getClient (id, options) {
-  var uri = this.configuration.issuer + '/v1/clients/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/clients/' + id
+  return request.bind(this)(options)
 }
 
 exports.get = getClient
@@ -69,27 +33,11 @@ exports.get = getClient
  */
 
 function createClient (data, options) {
-  var uri = this.configuration.issuer + '/v1/clients'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/clients'
+  options.method = 'POST'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.create = createClient
@@ -99,27 +47,11 @@ exports.create = createClient
  */
 
 function updateClient (id, data, options) {
-  var uri = this.configuration.issuer + '/v1/clients/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PATCH',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/clients/' + id
+  options.method = 'PATCH'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.update = updateClient
@@ -129,26 +61,11 @@ exports.update = updateClient
  */
 
 function deleteClient (id, options) {
-  var uri = this.configuration.issuer + '/v1/clients/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/clients/' + id
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.delete = deleteClient

--- a/rest/roleScopes.js
+++ b/rest/roleScopes.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Scopes
  */
 
 function listScopes (roleId, options) {
-  var uri = this.configuration.issuer + '/v1/roles/' + roleId + '/scopes'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles/' + roleId + '/scopes'
+  return request.bind(this)(options)
 }
 
 exports.listScopes = listScopes
@@ -38,28 +20,11 @@ exports.listScopes = listScopes
  * Add Scope
  */
 
-function addScope (role, scope) {
-  var uri = this.configuration.issuer + '/v1/roles/' + role + '/scopes/' + scope
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PUT',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+function addScope (role, scope, options) {
+  options = options || {}
+  options.url = '/v1/roles/' + role + '/scopes/' + scope
+  options.method = 'PUT'
+  return request.bind(this)(options)
 }
 
 exports.addScope = addScope
@@ -68,27 +33,12 @@ exports.addScope = addScope
  * Delete Scope
  */
 
-function deleteScope (role, scope) {
-  var uri = this.configuration.issuer + '/v1/roles/' + role + '/scopes/' + scope
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+function deleteScope (role, scope, options) {
+  options = options || {}
+  options.url = '/v1/roles/' + role + '/scopes/' + scope
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.deleteScope = deleteScope

--- a/rest/roles.js
+++ b/rest/roles.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Roles
  */
 
 function listRoles (options) {
-  var uri = this.configuration.issuer + '/v1/roles'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles'
+  return request.bind(this)(options)
 }
 
 exports.list = listRoles
@@ -39,27 +21,9 @@ exports.list = listRoles
  */
 
 function getRole (id, options) {
-  var uri = this.configuration.issuer + '/v1/roles/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles/' + id
+  return request.bind(this)(options)
 }
 
 exports.get = getRole
@@ -69,27 +33,11 @@ exports.get = getRole
  */
 
 function createRole (data, options) {
-  var uri = this.configuration.issuer + '/v1/roles'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles'
+  options.method = 'POST'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.create = createRole
@@ -99,27 +47,11 @@ exports.create = createRole
  */
 
 function updateRole (id, data, options) {
-  var uri = this.configuration.issuer + '/v1/roles/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PATCH',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles/' + id
+  options.method = 'PATCH'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.update = updateRole
@@ -129,26 +61,11 @@ exports.update = updateRole
  */
 
 function deleteRole (id, options) {
-  var uri = this.configuration.issuer + '/v1/roles/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/roles/' + id
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.delete = deleteRole

--- a/rest/scopes.js
+++ b/rest/scopes.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Scopes
  */
 
 function listScopes (options) {
-  var uri = this.configuration.issuer + '/v1/scopes'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/scopes'
+  return request.bind(this)(options)
 }
 
 exports.list = listScopes
@@ -39,27 +21,9 @@ exports.list = listScopes
  */
 
 function getScope (id, options) {
-  var uri = this.configuration.issuer + '/v1/scopes/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/scopes/' + id
+  return request.bind(this)(options)
 }
 
 exports.get = getScope
@@ -69,27 +33,11 @@ exports.get = getScope
  */
 
 function createScope (data, options) {
-  var uri = this.configuration.issuer + '/v1/scopes'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/scopes'
+  options.method = 'POST'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.create = createScope
@@ -99,27 +47,11 @@ exports.create = createScope
  */
 
 function updateScope (id, data, options) {
-  var uri = this.configuration.issuer + '/v1/scopes/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PATCH',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/scopes/' + id
+  options.method = 'PATCH'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.update = updateScope
@@ -129,26 +61,11 @@ exports.update = updateScope
  */
 
 function deleteScope (id, options) {
-  var uri = this.configuration.issuer + '/v1/scopes/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/scopes/' + id
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.delete = deleteScope

--- a/rest/userRoles.js
+++ b/rest/userRoles.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Roles
  */
 
 function listRoles (userId, options) {
-  var uri = this.configuration.issuer + '/v1/users/' + userId + '/roles'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users/' + userId + '/roles'
+  return request.bind(this)(options)
 }
 
 exports.listRoles = listRoles
@@ -38,28 +20,11 @@ exports.listRoles = listRoles
  * Add Role
  */
 
-function addRole (userId, role) {
-  var uri = this.configuration.issuer + '/v1/users/' + userId + '/roles/' + role
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PUT',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+function addRole (user, role, options) {
+  options = options || {}
+  options.url = '/v1/users/' + user + '/roles/' + role
+  options.method = 'PUT'
+  return request.bind(this)(options)
 }
 
 exports.addRole = addRole
@@ -68,27 +33,12 @@ exports.addRole = addRole
  * Delete Role
  */
 
-function deleteRole (userId, role) {
-  var uri = this.configuration.issuer + '/v1/users/' + userId + '/roles/' + role
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+function deleteRole (user, role, options) {
+  options = options || {}
+  options.url = '/v1/users/' + user + '/roles/' + role
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.deleteRole = deleteRole

--- a/rest/users.js
+++ b/rest/users.js
@@ -2,34 +2,16 @@
  * Module dependencies
  */
 
-var request = require('request-promise')
+var request = require('../lib/request')
 
 /**
  * List Users
  */
 
 function listUsers (options) {
-  var uri = this.configuration.issuer + '/v1/users'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users'
+  return request.bind(this)(options)
 }
 
 exports.list = listUsers
@@ -39,27 +21,9 @@ exports.list = listUsers
  */
 
 function getUser (id, options) {
-  var uri = this.configuration.issuer + '/v1/users/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'GET',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users/' + id
+  return request.bind(this)(options)
 }
 
 exports.get = getUser
@@ -69,27 +33,11 @@ exports.get = getUser
  */
 
 function createUser (data, options) {
-  var uri = this.configuration.issuer + '/v1/users'
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'POST',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users'
+  options.method = 'POST'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.create = createUser
@@ -99,27 +47,11 @@ exports.create = createUser
  */
 
 function updateUser (id, data, options) {
-  var uri = this.configuration.issuer + '/v1/users/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'PATCH',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: data,
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users/' + id
+  options.method = 'PATCH'
+  options.json = data
+  return request.bind(this)(options)
 }
 
 exports.update = updateUser
@@ -129,26 +61,11 @@ exports.update = updateUser
  */
 
 function deleteUser (id, options) {
-  var uri = this.configuration.issuer + '/v1/users/' + id
-  var token = this.tokens.access_token
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    request({
-      url: uri,
-      method: 'DELETE',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      agentOptions: self.agentOptions
-    })
-    .then(function (data) {
-      resolve(data)
-    })
-    .catch(function (err) {
-      reject(err)
-    })
-  })
+  options = options || {}
+  options.url = '/v1/users/' + id
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
 }
 
 exports.delete = deleteUser

--- a/test/anvilClientSpec.coffee
+++ b/test/anvilClientSpec.coffee
@@ -896,14 +896,32 @@ describe 'Anvil Connect Client', ->
 
   describe 'userInfo', ->
 
+    describe 'with a missing access token', ->
+
+      beforeEach (done) ->
+        anvil = new AnvilConnect config
+        anvil.configuration = openid
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = anvil.userInfo().then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide userInfo', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       beforeEach (done) ->
         anvil = new AnvilConnect config
         anvil.configuration = openid
-        anvil.tokens =
-          access_token: 'jwt1'
-          id_token: 'jwt2'
 
         nock(anvil.issuer)
           .get('/userinfo')
@@ -913,7 +931,7 @@ describe 'Anvil Connect Client', ->
           done()
         failure = sinon.spy ->
           done()
-        promise = anvil.userInfo()
+        promise = anvil.userInfo({ token: 'token' })
           .then(success)
           .catch(failure)
 
@@ -935,9 +953,6 @@ describe 'Anvil Connect Client', ->
       beforeEach (done) ->
         anvil = new AnvilConnect config
         anvil.configuration = openid
-        anvil.tokens =
-          access_token: 'jwt1'
-          id_token: 'jwt2'
 
         nock(anvil.issuer)
           .get('/userinfo')
@@ -947,7 +962,7 @@ describe 'Anvil Connect Client', ->
           done()
         failure = sinon.spy ->
           done()
-        promise = anvil.userInfo()
+        promise = anvil.userInfo({ token: 'token' })
           .then(success)
           .catch(failure)
 
@@ -961,7 +976,7 @@ describe 'Anvil Connect Client', ->
         success.should.not.have.been.called
 
       it 'should catch an error', ->
-        failure.should.have.been.called
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
 
 
 

--- a/test/lib/protectedAPIRequest.coffee
+++ b/test/lib/protectedAPIRequest.coffee
@@ -1,0 +1,73 @@
+# Test dependencies
+cwd         = process.cwd()
+path        = require 'path'
+chai        = require 'chai'
+sinon       = require 'sinon'
+sinonChai   = require 'sinon-chai'
+expect      = chai.expect
+
+
+
+
+# Assertions
+chai.use sinonChai
+chai.should()
+
+
+
+
+request = require path.join(cwd, 'lib', 'request')
+
+
+
+
+describe 'Protected API Request', ->
+
+  instance =
+    configuration: { issuer: 'https://connect.example.com' }
+    agentOptions: {}
+
+  describe 'with missing access token', ->
+
+    {promise,success,failure} = {}
+
+    before (done) ->
+      success = sinon.spy -> done()
+      failure = sinon.spy -> done()
+      promise = request.bind(instance)({
+        url: '/'
+      }).then(success, failure)
+
+    it 'should return a promise', ->
+      promise.should.be.instanceOf Promise
+
+    it 'should not resolve', ->
+      success.should.not.have.been.called
+
+    it 'should reject', ->
+      failure.should.have.been.calledWith sinon.match({
+        message: 'Missing access token'
+      })
+
+
+  describe 'with missing request url', ->
+
+    {promise,success,failure} = {}
+
+    before (done) ->
+      success = sinon.spy -> done()
+      failure = sinon.spy -> done()
+      promise = request.bind(instance)({}).then(success, failure)
+
+    it 'should return a promise', ->
+      promise.should.be.instanceOf Promise
+
+    it 'should not resolve', ->
+      success.should.not.have.been.called
+
+    it 'should reject', ->
+      failure.should.have.been.calledWith sinon.match({
+        message: 'Missing request url'
+      })
+
+

--- a/test/rest/clientSpec.coffee
+++ b/test/rest/clientSpec.coffee
@@ -1,5 +1,4 @@
 # Test dependencies
-#fs          = require 'fs'
 cwd         = process.cwd()
 path        = require 'path'
 chai        = require 'chai'
@@ -27,18 +26,17 @@ describe 'REST API Client Methods', ->
 
   describe 'list', ->
 
-    describe 'with a successful response', ->
+    describe 'with a missing access token', ->
 
       {promise,success,failure} = {}
 
-      before (done) ->
+      beforeEach (done) ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/clients')
           .reply(200, [{_id: 'uuid'}])
@@ -47,6 +45,37 @@ describe 'REST API Client Methods', ->
         failure = sinon.spy -> done()
 
         promise = clients.list.bind(instance)()
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide clients', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/clients')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clients.list.bind(instance)({ token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -67,10 +96,9 @@ describe 'REST API Client Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/clients')
           .reply(404, 'Not found')
@@ -78,11 +106,8 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.list.bind(instance)()
+        promise = clients.list.bind(instance)({ token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -96,6 +121,37 @@ describe 'REST API Client Methods', ->
 
   describe 'get', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/clients/uuid')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clients.get.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide clients', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -108,6 +164,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/clients/uuid')
           .reply(200, {_id: 'uuid'})
@@ -115,7 +172,7 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.get.bind(instance)('uuid')
+        promise = clients.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -140,6 +197,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/clients/uuid')
           .reply(404, 'Not found')
@@ -147,11 +205,8 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.get.bind(instance)('uuid')
+        promise = clients.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -167,6 +222,37 @@ describe 'REST API Client Methods', ->
 
   describe 'create', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .post('/v1/clients')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clients.create.bind(instance)({})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide client', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -179,6 +265,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/clients', {
             redirect_uris: ['https://example.anvil.io']
@@ -193,6 +280,8 @@ describe 'REST API Client Methods', ->
 
         promise = clients.create.bind(instance)({
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -217,6 +306,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/clients', {})
           .reply(400, 'Bad request')
@@ -224,11 +314,11 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.create.bind(instance)({})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = clients.create.bind(instance)({
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -244,6 +334,38 @@ describe 'REST API Client Methods', ->
 
   describe 'update', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .patch('/v1/clients/uuid')
+          .reply(200, {_id: 'uuid'})
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clients.update.bind(instance)('uuid', {})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide client', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -256,6 +378,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/clients/uuid', {
             redirect_uris: ['https://example.anvil.io']
@@ -270,6 +393,8 @@ describe 'REST API Client Methods', ->
 
         promise = clients.update.bind(instance)('uuid', {
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -296,6 +421,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/clients/uuid', {})
           .reply(400, 'Bad request')
@@ -303,11 +429,11 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.update.bind(instance)('uuid', {})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = clients.update.bind(instance)('uuid', {
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -322,6 +448,38 @@ describe 'REST API Client Methods', ->
 
   describe 'delete', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/clients/uuid')
+          .reply(401, 'Unauthorized')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clients.delete.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide client', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -334,6 +492,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/clients/uuid')
           .reply(204)
@@ -341,7 +500,7 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.delete.bind(instance)('uuid')
+        promise = clients.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -366,6 +525,7 @@ describe 'REST API Client Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/clients/uuid')
           .reply(404, 'Not found')
@@ -373,11 +533,8 @@ describe 'REST API Client Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = clients.delete.bind(instance)('uuid')
+        promise = clients.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise

--- a/test/rest/roleScopesSpec.coffee
+++ b/test/rest/roleScopesSpec.coffee
@@ -35,10 +35,9 @@ describe 'REST API Role Scope Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/roles/authority/scopes')
           .reply(200, [{name: 'realm'}])
@@ -46,8 +45,9 @@ describe 'REST API Role Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roleScopes.listScopes.bind(instance)('authority')
-          .then(success, failure)
+        promise = roleScopes.listScopes.bind(instance)('authority', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -106,10 +106,9 @@ describe 'REST API Role Scope Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .put('/v1/roles/authority/scopes/realm')
           .reply(201, {
@@ -119,8 +118,9 @@ describe 'REST API Role Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roleScopes.addScope.bind(instance)('authority', 'realm')
-                    .then(success, failure)
+        promise = roleScopes.addScope.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -144,6 +144,7 @@ describe 'REST API Role Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .put('/v1/roles/invalid/scopes/addition')
           .reply(400, 'Bad request')
@@ -151,11 +152,9 @@ describe 'REST API Role Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roleScopes.addScope.bind(instance)('invalid', 'addition')
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = roleScopes.addScope.bind(instance)('invalid', 'addition', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -183,6 +182,7 @@ describe 'REST API Role Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/roles/authority/scopes/realm')
           .reply(204)
@@ -190,8 +190,9 @@ describe 'REST API Role Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roleScopes.deleteScope.bind(instance)('authority', 'realm')
-          .then(success, failure)
+        promise = roleScopes.deleteScope.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -215,6 +216,7 @@ describe 'REST API Role Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/roles/invalid/scopes/deletion')
           .reply(404, 'Not found')
@@ -222,8 +224,9 @@ describe 'REST API Role Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roleScopes.deleteScope.bind(instance)('invalid', 'deletion')
-          .then(success, failure)
+        promise = roleScopes.deleteScope.bind(instance)('invalid', 'deletion', {
+          token: 'token'
+        }).then(success, failure)
 
       after ->
         nock.cleanAll()

--- a/test/rest/roleSpec.coffee
+++ b/test/rest/roleSpec.coffee
@@ -1,5 +1,4 @@
 # Test dependencies
-#fs          = require 'fs'
 cwd         = process.cwd()
 path        = require 'path'
 chai        = require 'chai'
@@ -27,18 +26,17 @@ describe 'REST API Role Methods', ->
 
   describe 'list', ->
 
-    describe 'with a successful response', ->
+    describe 'with a missing access token', ->
 
       {promise,success,failure} = {}
 
-      before (done) ->
+      beforeEach (done) ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/roles')
           .reply(200, [{_id: 'uuid'}])
@@ -47,6 +45,37 @@ describe 'REST API Role Methods', ->
         failure = sinon.spy -> done()
 
         promise = roles.list.bind(instance)()
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide roles', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/roles')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = roles.list.bind(instance)({ token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -67,10 +96,9 @@ describe 'REST API Role Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/roles')
           .reply(404, 'Not found')
@@ -78,11 +106,8 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.list.bind(instance)()
+        promise = roles.list.bind(instance)({ token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -96,6 +121,37 @@ describe 'REST API Role Methods', ->
 
   describe 'get', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/roles/uuid')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = roles.get.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide roles', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -108,6 +164,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/roles/uuid')
           .reply(200, {_id: 'uuid'})
@@ -115,7 +172,7 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.get.bind(instance)('uuid')
+        promise = roles.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -140,6 +197,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/roles/uuid')
           .reply(404, 'Not found')
@@ -147,11 +205,8 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.get.bind(instance)('uuid')
+        promise = roles.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -167,6 +222,37 @@ describe 'REST API Role Methods', ->
 
   describe 'create', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .post('/v1/roles')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = roles.create.bind(instance)({})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide role', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -179,6 +265,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/roles', {
             redirect_uris: ['https://example.anvil.io']
@@ -193,6 +280,8 @@ describe 'REST API Role Methods', ->
 
         promise = roles.create.bind(instance)({
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -217,6 +306,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/roles', {})
           .reply(400, 'Bad request')
@@ -224,11 +314,11 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.create.bind(instance)({})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = roles.create.bind(instance)({
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -244,6 +334,38 @@ describe 'REST API Role Methods', ->
 
   describe 'update', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .patch('/v1/roles/uuid')
+          .reply(200, {_id: 'uuid'})
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = roles.update.bind(instance)('uuid', {})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide role', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -256,6 +378,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/roles/uuid', {
             redirect_uris: ['https://example.anvil.io']
@@ -270,6 +393,8 @@ describe 'REST API Role Methods', ->
 
         promise = roles.update.bind(instance)('uuid', {
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -296,6 +421,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/roles/uuid', {})
           .reply(400, 'Bad request')
@@ -303,11 +429,11 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.update.bind(instance)('uuid', {})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = roles.update.bind(instance)('uuid', {
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -322,6 +448,38 @@ describe 'REST API Role Methods', ->
 
   describe 'delete', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/roles/uuid')
+          .reply(401, 'Unauthorized')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = roles.delete.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide role', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -334,6 +492,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/roles/uuid')
           .reply(204)
@@ -341,7 +500,7 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.delete.bind(instance)('uuid')
+        promise = roles.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -366,6 +525,7 @@ describe 'REST API Role Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/roles/uuid')
           .reply(404, 'Not found')
@@ -373,11 +533,8 @@ describe 'REST API Role Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = roles.delete.bind(instance)('uuid')
+        promise = roles.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise

--- a/test/rest/scopeSpec.coffee
+++ b/test/rest/scopeSpec.coffee
@@ -1,5 +1,4 @@
 # Test dependencies
-#fs          = require 'fs'
 cwd         = process.cwd()
 path        = require 'path'
 chai        = require 'chai'
@@ -27,18 +26,17 @@ describe 'REST API Scope Methods', ->
 
   describe 'list', ->
 
-    describe 'with a successful response', ->
+    describe 'with a missing access token', ->
 
       {promise,success,failure} = {}
 
-      before (done) ->
+      beforeEach (done) ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/scopes')
           .reply(200, [{_id: 'uuid'}])
@@ -47,6 +45,37 @@ describe 'REST API Scope Methods', ->
         failure = sinon.spy -> done()
 
         promise = scopes.list.bind(instance)()
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide scopes', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/scopes')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = scopes.list.bind(instance)({ token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -67,10 +96,9 @@ describe 'REST API Scope Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/scopes')
           .reply(404, 'Not found')
@@ -78,11 +106,8 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.list.bind(instance)()
+        promise = scopes.list.bind(instance)({ token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -96,6 +121,37 @@ describe 'REST API Scope Methods', ->
 
   describe 'get', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/scopes/uuid')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = scopes.get.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide scopes', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -108,6 +164,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/scopes/uuid')
           .reply(200, {_id: 'uuid'})
@@ -115,7 +172,7 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.get.bind(instance)('uuid')
+        promise = scopes.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -140,6 +197,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/scopes/uuid')
           .reply(404, 'Not found')
@@ -147,11 +205,8 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.get.bind(instance)('uuid')
+        promise = scopes.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -167,6 +222,37 @@ describe 'REST API Scope Methods', ->
 
   describe 'create', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .post('/v1/scopes')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = scopes.create.bind(instance)({})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide scope', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -179,6 +265,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/scopes', {
             redirect_uris: ['https://example.anvil.io']
@@ -193,6 +280,8 @@ describe 'REST API Scope Methods', ->
 
         promise = scopes.create.bind(instance)({
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -217,6 +306,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/scopes', {})
           .reply(400, 'Bad request')
@@ -224,11 +314,11 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.create.bind(instance)({})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = scopes.create.bind(instance)({
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -244,6 +334,38 @@ describe 'REST API Scope Methods', ->
 
   describe 'update', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .patch('/v1/scopes/uuid')
+          .reply(200, {_id: 'uuid'})
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = scopes.update.bind(instance)('uuid', {})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide scope', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -256,6 +378,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/scopes/uuid', {
             redirect_uris: ['https://example.anvil.io']
@@ -270,6 +393,8 @@ describe 'REST API Scope Methods', ->
 
         promise = scopes.update.bind(instance)('uuid', {
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -296,6 +421,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/scopes/uuid', {})
           .reply(400, 'Bad request')
@@ -303,11 +429,11 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.update.bind(instance)('uuid', {})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = scopes.update.bind(instance)('uuid', {
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -322,6 +448,38 @@ describe 'REST API Scope Methods', ->
 
   describe 'delete', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/scopes/uuid')
+          .reply(401, 'Unauthorized')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = scopes.delete.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide scope', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -334,6 +492,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/scopes/uuid')
           .reply(204)
@@ -341,7 +500,7 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.delete.bind(instance)('uuid')
+        promise = scopes.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -366,6 +525,7 @@ describe 'REST API Scope Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/scopes/uuid')
           .reply(404, 'Not found')
@@ -373,11 +533,8 @@ describe 'REST API Scope Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = scopes.delete.bind(instance)('uuid')
+        promise = scopes.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise

--- a/test/rest/userRolesSpec.coffee
+++ b/test/rest/userRolesSpec.coffee
@@ -1,5 +1,4 @@
 # Test dependencies
-#fs          = require 'fs'
 cwd         = process.cwd()
 path        = require 'path'
 chai        = require 'chai'
@@ -23,7 +22,7 @@ userRoles = require path.join(cwd, 'rest', 'userRoles')
 
 
 
-describe 'REST API User Roles Methods', ->
+describe 'REST API User Role Methods', ->
 
   describe 'listRoles', ->
 
@@ -35,25 +34,25 @@ describe 'REST API User Roles Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
-          .get('/v1/users/uuid/roles')
-          .reply(200, [{name: 'authority'}])
+          .get('/v1/users/authority/roles')
+          .reply(200, [{name: 'realm'}])
 
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.listRoles.bind(instance)('uuid')
-          .then(success, failure)
+        promise = userRoles.listRoles.bind(instance)('authority', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
 
       it 'should provide the roles', ->
-        success.should.have.been.calledWith sinon.match [{name:'authority'}]
+        success.should.have.been.calledWith sinon.match [{name:'realm'}]
 
       it 'should not catch an error', ->
         failure.should.not.have.been.called
@@ -72,13 +71,13 @@ describe 'REST API User Roles Methods', ->
           agentOptions: {}
 
         nock(instance.configuration.issuer)
-          .get('/v1/users/unknown/roles')
+          .get('/v1/users/authority/roles')
           .reply(404, 'Not found')
 
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.listRoles.bind(instance)('unknown')
+        promise = userRoles.listRoles.bind(instance)('authority')
           .then(success, failure)
 
       after ->
@@ -106,12 +105,11 @@ describe 'REST API User Roles Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
-          .put('/v1/users/uuid/roles/authority')
+          .put('/v1/users/authority/roles/realm')
           .reply(201, {
             added: true
           })
@@ -119,8 +117,9 @@ describe 'REST API User Roles Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.addRole.bind(instance)('uuid', 'authority')
-                    .then(success, failure)
+        promise = userRoles.addRole.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -144,18 +143,17 @@ describe 'REST API User Roles Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
-          .put('/v1/users/unknown/roles/authority')
+          .put('/v1/users/invalid/roles/addition')
           .reply(400, 'Bad request')
 
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.addRole.bind(instance)('unknown', 'authority')
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = userRoles.addRole.bind(instance)('invalid', 'addition', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -183,15 +181,17 @@ describe 'REST API User Roles Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
-          .delete('/v1/users/uuid/roles/authority')
+          .delete('/v1/users/authority/roles/realm')
           .reply(204)
 
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.deleteRole.bind(instance)('uuid', 'authority')
-          .then(success, failure)
+        promise = userRoles.deleteRole.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -215,15 +215,17 @@ describe 'REST API User Roles Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
-          .delete('/v1/users/unknown/roles/authority')
+          .delete('/v1/users/invalid/roles/deletion')
           .reply(404, 'Not found')
 
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = userRoles.deleteRole.bind(instance)('unknown', 'authority')
-          .then(success, failure)
+        promise = userRoles.deleteRole.bind(instance)('invalid', 'deletion', {
+          token: 'token'
+        }).then(success, failure)
 
       after ->
         nock.cleanAll()

--- a/test/rest/userSpec.coffee
+++ b/test/rest/userSpec.coffee
@@ -1,5 +1,4 @@
 # Test dependencies
-#fs          = require 'fs'
 cwd         = process.cwd()
 path        = require 'path'
 chai        = require 'chai'
@@ -27,18 +26,17 @@ describe 'REST API User Methods', ->
 
   describe 'list', ->
 
-    describe 'with a successful response', ->
+    describe 'with a missing access token', ->
 
       {promise,success,failure} = {}
 
-      before (done) ->
+      beforeEach (done) ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/users')
           .reply(200, [{_id: 'uuid'}])
@@ -47,6 +45,37 @@ describe 'REST API User Methods', ->
         failure = sinon.spy -> done()
 
         promise = users.list.bind(instance)()
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide users', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/users')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = users.list.bind(instance)({ token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -67,10 +96,9 @@ describe 'REST API User Methods', ->
         instance =
           configuration:
             issuer: 'https://connect.anvil.io'
-          tokens:
-            access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/users')
           .reply(404, 'Not found')
@@ -78,11 +106,8 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.list.bind(instance)()
+        promise = users.list.bind(instance)({ token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -96,6 +121,37 @@ describe 'REST API User Methods', ->
 
   describe 'get', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/users/uuid')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = users.get.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide users', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -108,6 +164,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/users/uuid')
           .reply(200, {_id: 'uuid'})
@@ -115,7 +172,7 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.get.bind(instance)('uuid')
+        promise = users.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -140,6 +197,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .get('/v1/users/uuid')
           .reply(404, 'Not found')
@@ -147,11 +205,8 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.get.bind(instance)('uuid')
+        promise = users.get.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -167,6 +222,37 @@ describe 'REST API User Methods', ->
 
   describe 'create', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .post('/v1/users')
+          .reply(200, [{_id: 'uuid'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = users.create.bind(instance)({})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide user', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -179,6 +265,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/users', {
             redirect_uris: ['https://example.anvil.io']
@@ -193,6 +280,8 @@ describe 'REST API User Methods', ->
 
         promise = users.create.bind(instance)({
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -217,6 +306,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .post('/v1/users', {})
           .reply(400, 'Bad request')
@@ -224,11 +314,11 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.create.bind(instance)({})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = users.create.bind(instance)({
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -244,6 +334,38 @@ describe 'REST API User Methods', ->
 
   describe 'update', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .patch('/v1/users/uuid')
+          .reply(200, {_id: 'uuid'})
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = users.update.bind(instance)('uuid', {})
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide user', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -256,6 +378,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/users/uuid', {
             redirect_uris: ['https://example.anvil.io']
@@ -270,6 +393,8 @@ describe 'REST API User Methods', ->
 
         promise = users.update.bind(instance)('uuid', {
           redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
         }).then(success, failure)
 
       it 'should return a promise', ->
@@ -296,6 +421,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .patch('/v1/users/uuid', {})
           .reply(400, 'Bad request')
@@ -303,11 +429,11 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.update.bind(instance)('uuid', {})
-          .then(success, failure)
-
-      after ->
-        nock.cleanAll()
+        promise = users.update.bind(instance)('uuid', {
+          redirect_uris: ['https://example.anvil.io']
+        }, {
+          token: 'token'
+        }).then(success, failure)
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise
@@ -322,6 +448,38 @@ describe 'REST API User Methods', ->
 
   describe 'delete', ->
 
+    describe 'with a missing access token', ->
+
+      {promise,success,failure} = {}
+
+      beforeEach (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/users/uuid')
+          .reply(401, 'Unauthorized')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = users.delete.bind(instance)('uuid')
+          .then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide user', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.calledWith sinon.match.instanceOf Error
+
+
+
     describe 'with a successful response', ->
 
       {promise,success,failure} = {}
@@ -334,6 +492,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/users/uuid')
           .reply(204)
@@ -341,7 +500,7 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.delete.bind(instance)('uuid')
+        promise = users.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
 
       it 'should return a promise', ->
@@ -366,6 +525,7 @@ describe 'REST API User Methods', ->
             access_token: 'random'
           agentOptions: {}
 
+        nock.cleanAll()
         nock(instance.configuration.issuer)
           .delete('/v1/users/uuid')
           .reply(404, 'Not found')
@@ -373,11 +533,8 @@ describe 'REST API User Methods', ->
         success = sinon.spy -> done()
         failure = sinon.spy -> done()
 
-        promise = users.delete.bind(instance)('uuid')
+        promise = users.delete.bind(instance)('uuid', { token: 'token' })
           .then(success, failure)
-
-      after ->
-        nock.cleanAll()
 
       it 'should return a promise', ->
         promise.should.be.instanceof Promise


### PR DESCRIPTION
This PR is _not_ ready to merge. Prior to completing the required work and merging, I'm requesting user feedback on methods of passing access token arguments. 

The code in this branch uses an options object argument:

```javascript
anvil.userInfo({ token: 'ACCESS_TOKEN' }).then(success, failure)
```

An alternative would be:

```javascript
anvil.userInfo(token).then(success, failure)
```

The advantage of using an options arg, while more verbose in the simplest cases, is that we'll have some flexibility in adding features to the API, for example individual claims requests parameter could be added as an option without creating breaking changes.

Anyone have objections or suggestions?