### PR TITLE
Add client roles manipulation

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var qs = require('qs')
 var url = require('url')
 var async = require('async')
 var request = require('request-promise')
+var clientRoles = require('./rest/clientRoles')
 var clients = require('./rest/clients')
 var roles = require('./rest/roles')
 var roleScopes = require('./rest/roleScopes')
@@ -35,7 +36,12 @@ function AnvilConnect (options) {
     get: clients.get.bind(this),
     create: clients.create.bind(this),
     update: clients.update.bind(this),
-    delete: clients.delete.bind(this)
+    delete: clients.delete.bind(this),
+    roles: {
+      list: clientRoles.listRoles.bind(this),
+      add: clientRoles.addRole.bind(this),
+      delete: clientRoles.deleteRole.bind(this)
+    }
   }
 
   this.roles = {

--- a/rest/clientRoles.js
+++ b/rest/clientRoles.js
@@ -1,0 +1,44 @@
+/**
+ * Module dependencies
+ */
+
+var request = require('../lib/request')
+
+/**
+ * List Roles
+ */
+
+function listRoles (clientId, options) {
+  options = options || {}
+  options.url = '/v1/clients/' + clientId + '/roles'
+  return request.bind(this)(options)
+}
+
+exports.listRoles = listRoles
+
+/**
+ * Add Role
+ */
+
+function addRole (client, role, options) {
+  options = options || {}
+  options.url = '/v1/clients/' + client + '/roles/' + role
+  options.method = 'PUT'
+  return request.bind(this)(options)
+}
+
+exports.addRole = addRole
+
+/**
+ * Delete Role
+ */
+
+function deleteRole (client, role, options) {
+  options = options || {}
+  options.url = '/v1/clients/' + client + '/roles/' + role
+  options.method = 'DELETE'
+  delete options.json
+  return request.bind(this)(options)
+}
+
+exports.deleteRole = deleteRole

--- a/test/rest/clientRolesSpec.coffee
+++ b/test/rest/clientRolesSpec.coffee
@@ -1,0 +1,242 @@
+# Test dependencies
+cwd         = process.cwd()
+path        = require 'path'
+chai        = require 'chai'
+sinon       = require 'sinon'
+sinonChai   = require 'sinon-chai'
+expect      = chai.expect
+nock        = require 'nock'
+
+
+
+
+# Assertions
+chai.use sinonChai
+chai.should()
+
+
+
+
+clientRoles = require path.join(cwd, 'rest', 'clientRoles')
+
+
+
+
+describe 'REST API Client Role Methods', ->
+
+  describe 'listRoles', ->
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .get('/v1/clients/authority/roles')
+          .reply(200, [{name: 'realm'}])
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.listRoles.bind(instance)('authority', {
+          token: 'token'
+        }).then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should provide the roles', ->
+        success.should.have.been.calledWith sinon.match [{name:'realm'}]
+
+      it 'should not catch an error', ->
+        failure.should.not.have.been.called
+
+
+    describe 'with a failure response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          tokens:
+            access_token: 'random'
+          agentOptions: {}
+
+        nock(instance.configuration.issuer)
+          .get('/v1/clients/authority/roles')
+          .reply(404, 'Not found')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.listRoles.bind(instance)('authority')
+          .then(success, failure)
+
+      after ->
+        nock.cleanAll()
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide the roles', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.called
+
+
+
+
+  describe 'add', ->
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .put('/v1/clients/authority/roles/realm')
+          .reply(201, {
+            added: true
+          })
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.addRole.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should provide the role', ->
+        success.should.have.been.calledWith sinon.match { added: true }
+
+      it 'should not catch an error', ->
+        failure.should.not.have.been.called
+
+
+    describe 'with a failure response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          tokens:
+            access_token: 'random'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .put('/v1/clients/invalid/roles/addition')
+          .reply(400, 'Bad request')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.addRole.bind(instance)('invalid', 'addition', {
+          token: 'token'
+        }).then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide the role', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.called
+
+
+
+
+  describe 'delete', ->
+
+    describe 'with a successful response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          tokens:
+            access_token: 'random'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/clients/authority/roles/realm')
+          .reply(204)
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.deleteRole.bind(instance)('authority', 'realm', {
+          token: 'token'
+        }).then(success, failure)
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should provide the role', ->
+        success.should.have.been.called
+
+      it 'should not catch an error', ->
+        failure.should.not.have.been.called
+
+
+    describe 'with a failure response', ->
+
+      {promise,success,failure} = {}
+
+      before (done) ->
+        instance =
+          configuration:
+            issuer: 'https://connect.anvil.io'
+          tokens:
+            access_token: 'random'
+          agentOptions: {}
+
+        nock.cleanAll()
+        nock(instance.configuration.issuer)
+          .delete('/v1/clients/invalid/roles/deletion')
+          .reply(404, 'Not found')
+
+        success = sinon.spy -> done()
+        failure = sinon.spy -> done()
+
+        promise = clientRoles.deleteRole.bind(instance)('invalid', 'deletion', {
+          token: 'token'
+        }).then(success, failure)
+
+      after ->
+        nock.cleanAll()
+
+      it 'should return a promise', ->
+        promise.should.be.instanceof Promise
+
+      it 'should not provide the role', ->
+        success.should.not.have.been.called
+
+      it 'should catch an error', ->
+        failure.should.have.been.called
+
+


### PR DESCRIPTION
This adds the client-side API for manipulating roles associated with a client through the REST API added in anvilresearch/connect#306.